### PR TITLE
Exit non-zero for Critical cert errors in cmdline util.

### DIFF
--- a/certlint.go
+++ b/certlint.go
@@ -135,6 +135,9 @@ func main() {
 		for _, err := range result.Errors.List() {
 			fmt.Println(err)
 		}
+		if result.Errors.Priority() > errors.Warning {
+			os.Exit(1)
+		}
 	}
 }
 


### PR DESCRIPTION
When checking a single certificate on the command-line, it is useful to have `certlint` exit with a non-zero return value if Critical errors are discovered in the certificate.