### PR TITLE
Clarify output from command-line tool.

### DIFF
--- a/certlint.go
+++ b/certlint.go
@@ -132,7 +132,7 @@ func main() {
 
 	fmt.Println("Processed Certificate Type:", result.Type)
 	if result.Errors != nil {
-		fmt.Println("Certificate Errors:")
+		fmt.Printf("Certificate Errors: %v\n", len(result.Errors.List()))
 		for _, err := range result.Errors.List() {
 			fmt.Printf("  Priority: %s, Message: %v\n", err.Priority(), err)
 		}

--- a/certlint.go
+++ b/certlint.go
@@ -132,9 +132,9 @@ func main() {
 
 	fmt.Println("Processed Certificate Type:", result.Type)
 	if result.Errors != nil {
-		fmt.Printf("Certificate Errors: %v\n", len(result.Errors.List()))
+		fmt.Printf("Certificate Errors: %d\n", len(result.Errors.List()))
 		for _, err := range result.Errors.List() {
-			fmt.Printf("  Priority: %s, Message: %v\n", err.Priority(), err)
+			fmt.Printf("  Priority: %s, Message: %s\n", err.Priority(), err.Error())
 		}
 		if result.Errors.Priority() > errors.Warning {
 			os.Exit(1)

--- a/certlint.go
+++ b/certlint.go
@@ -130,10 +130,11 @@ func main() {
 	der := getCertificate(*cert)
 	result := do(nil, der, *expired, true)
 
-	fmt.Println("Certificate Type:", result.Type)
+	fmt.Println("Processed Certificate Type:", result.Type)
 	if result.Errors != nil {
+		fmt.Println("Certificate Errors:")
 		for _, err := range result.Errors.List() {
-			fmt.Println(err)
+			fmt.Printf("  Priority: %s, Message: %v\n", err.Priority(), err)
 		}
 		if result.Errors.Priority() > errors.Warning {
 			os.Exit(1)


### PR DESCRIPTION
This proposed change makes the command-line utility output appear as follows:
```
$ certlint -cert testdata/evissues.pem 
Incomplete chain for VR IDENT EV SSL CA 2016 W1.DONNER.DE 68636c860bca0d94ab2be &{[] <nil> 0 {0 0}}
Processed Certificate Type: EV
Certificate Errors: 5
  Priority: Error, Message: Certificate contains no Authority Info Access Issuers
  Priority: Error, Message: businessCategory is required for EV certificates
  Priority: Error, Message: jurisdictionCountryName is required for EV certificates
  Priority: Error, Message: serialNumber is required for EV certificates
  Priority: Info, Message: commonName field is deprecated
```