### PR TITLE
Code lint fixes from go fmt and go generate.

### DIFF
--- a/certlint.go
+++ b/certlint.go
@@ -50,15 +50,15 @@ type testResult struct {
 }
 
 // if errors package changes, this must change
-var priorityMap = map[string]errors.Priority {
-	"debug"     : errors.Debug,
-	"info"      : errors.Info,
-	"notice"    : errors.Notice,
-	"warning"   : errors.Warning,
-	"error"     : errors.Error,
-	"critical"  : errors.Critical,
-	"alert"     : errors.Alert,
-	"emergency" : errors.Emergency,
+var priorityMap = map[string]errors.Priority{
+	"debug":     errors.Debug,
+	"info":      errors.Info,
+	"notice":    errors.Notice,
+	"warning":   errors.Warning,
+	"error":     errors.Error,
+	"critical":  errors.Critical,
+	"alert":     errors.Alert,
+	"emergency": errors.Emergency,
 }
 
 var jobs = make(chan []byte, 100)
@@ -92,7 +92,7 @@ func main() {
 
 	errlevel := strings.ToLower(*flagErr)
 	// Sanity-check for flagErr
-	if _, included := priorityMap[errlevel]; ! included {
+	if _, included := priorityMap[errlevel]; !included {
 		fmt.Println("Supplied -errlevel is invalid")
 		os.Exit(1)
 	}

--- a/errors/priority_string.go
+++ b/errors/priority_string.go
@@ -2,7 +2,7 @@
 
 package errors
 
-import "fmt"
+import "strconv"
 
 const _Priority_name = "UnknownDebugInfoNoticeWarningErrorCriticalAlertEmergency"
 
@@ -10,7 +10,7 @@ var _Priority_index = [...]uint8{0, 7, 12, 16, 22, 29, 34, 42, 47, 56}
 
 func (i Priority) String() string {
 	if i < 0 || i >= Priority(len(_Priority_index)-1) {
-		return fmt.Sprintf("Priority(%d)", i)
+		return "Priority(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _Priority_name[_Priority_index[i]:_Priority_index[i+1]]
 }


### PR DESCRIPTION
Apparently go 1.10 prefers using `strconv` over `fmt` in the generated `priority_string` code.
This may or may not be a reason to reject that change, as it is NOT tested with older versions of go.