### PR TITLE
Add tests for CLI utility.

### DIFF
--- a/certlint_test.go
+++ b/certlint_test.go
@@ -169,6 +169,11 @@ func TestCLIReturn(t *testing.T) {
 			[]string{"-expired", "-cert", "testdata/invalid_encoding2.pem"},
 			"exit status 1",
 		},
+		{
+			"Supplied Error Level Invalid",
+			[]string{"-expired", "-errlevel", "garbage", "-cert", "testdata/invalid_encoding2.pem"},
+			"exit status 1",
+		},
 	}
 
 	dir, err := os.Getwd()

--- a/certlint_test.go
+++ b/certlint_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/pem"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -50,6 +51,8 @@ tfy6WBz8/93RDvNodNhlokJOibmZ8X3xvXMqAPFbeX6YLjWsl4z30ZnMUi2g+SQa
 accZ5e1iOtNIBTVUEaQ0YxNwhZqnQO4rgBFCnEpNH6TB62hXUD6u/oP/WB48Wmek
 KPgaoWHMo5sOFQnw5A==
 -----END CERTIFICATE-----`
+
+var update = flag.Bool("update", false, "Update golden files.")
 
 func TestMain(m *testing.M) {
 	build := exec.Command("go", "build")
@@ -100,7 +103,11 @@ func TestCLITestData(t *testing.T) {
 		t.Fatal(err)
 	}
 	testdata := path.Join(dir, "testdata")
-	files, _ := filepath.Glob("./testdata/*.pem")
+	dataglob := "ev*.pem"
+	if *update {
+		dataglob = "*.pem"
+	}
+	files, _ := filepath.Glob(path.Join(testdata, dataglob))
 	for _, f := range files {
 		fname := path.Base(f)
 		t.Run(fname, func(t *testing.T) {
@@ -119,9 +126,10 @@ func TestCLITestData(t *testing.T) {
 			}
 
 			// TODO: allow for programatic refresh of golden files as a test argument
-			//if *update {
-			//	ioutil.WriteFile(golden, output, 0640)
-			//}
+			if *update {
+				ioutil.WriteFile(golden, output, 0640)
+				t.Logf("Wrote new output to golden file: %s", golden)
+			}
 
 			actual := string(output)
 

--- a/testdata/1024cert.pem.golden
+++ b/testdata/1024cert.pem.golden
@@ -1,0 +1,8 @@
+Processed Certificate Type: OV
+Certificate Errors: 6
+  Priority: Error, Message: Certificate contains no extended key usage
+  Priority: Error, Message: Certificate has key usage KeyAgreement set
+  Priority: Error, Message: Certificate key too small: 1024
+  Priority: Error, Message: Certificate contains a CRL with an non-preferred scheme (ldap)
+  Priority: Error, Message: Certificate is using SHA1, but is still valid on/after 1 Jan 2017
+  Priority: Info, Message: commonName field is deprecated

--- a/testdata/2043bit.pem.golden
+++ b/testdata/2043bit.pem.golden
@@ -1,0 +1,8 @@
+Processed Certificate Type: DV
+Certificate Errors: 6
+  Priority: Error, Message: KeyUsage extension SHOULD be marked as critical when present
+  Priority: Warning, Message: Certificate contains unknown extension (2.5.29.18)
+  Priority: Error, Message: Certificate has key usage KeyAgreement set
+  Priority: Error, Message: Certificate key too small: 2043
+  Priority: Info, Message: commonName field is deprecated
+  Priority: Info, Message: emailAddress field is deprecated

--- a/testdata/512bit.pem.golden
+++ b/testdata/512bit.pem.golden
@@ -1,0 +1,7 @@
+Processed Certificate Type: PS
+Certificate Errors: 5
+  Priority: Error, Message: Certificate contains an extended key usage different from ClientAuth or EmailProtection
+  Priority: Error, Message: Certificate key too small: 512
+  Priority: Error, Message: Certificate contains a CRL with an non-preferred scheme (ldap)
+  Priority: Info, Message: commonName field is deprecated
+  Priority: Info, Message: emailAddress field is deprecated

--- a/testdata/cat.pem.golden
+++ b/testdata/cat.pem.golden
@@ -1,0 +1,4 @@
+Processed Certificate Type: -
+Certificate Errors: 2
+  Priority: Error, Message: Forbidden value in PrintableString '-'
+  Priority: Error, Message: Forbidden value in PrintableString '-'

--- a/testdata/evissues.pem.golden
+++ b/testdata/evissues.pem.golden
@@ -1,0 +1,8 @@
+Incomplete chain for VR IDENT EV SSL CA 2016 W1.DONNER.DE 68636c860bca0d94ab2be &{[] <nil> 0 {0 0}}
+Processed Certificate Type: EV
+Certificate Errors: 5
+  Priority: Error, Message: Certificate contains no Authority Info Access Issuers
+  Priority: Error, Message: businessCategory is required for EV certificates
+  Priority: Error, Message: jurisdictionCountryName is required for EV certificates
+  Priority: Error, Message: serialNumber is required for EV certificates
+  Priority: Info, Message: commonName field is deprecated

--- a/testdata/evissues2.pem.golden
+++ b/testdata/evissues2.pem.golden
@@ -1,0 +1,9 @@
+Incomplete chain for CA de Certificados SSL EV www.manaria.eus 1d94f10d7dda98d257188b794b882346 &{[] <nil> 0 {0 0}}
+Processed Certificate Type: EV
+Certificate Errors: 6
+  Priority: Error, Message: Certificate contains no Authority Info Access Issuers
+  Priority: Warning, Message: Certificate contains unknown extension (2.5.29.18)
+  Priority: Error, Message: localityName is required for EV certificates
+  Priority: Error, Message: localityName or stateOrProvinceName is required if organizationName is set
+  Priority: Error, Message: stateOrProvinceName is required if organizationName is set
+  Priority: Info, Message: commonName field is deprecated

--- a/testdata/exponent1.pem.golden
+++ b/testdata/exponent1.pem.golden
@@ -1,0 +1,8 @@
+Processed Certificate Type: OV
+Certificate Errors: 6
+  Priority: Error, Message: KeyUsage extension SHOULD be marked as critical when present
+  Priority: Warning, Message: Certificate contains unknown extension (2.5.29.18)
+  Priority: Error, Message: Certificate has key usage KeyAgreement set
+  Priority: Error, Message: Certificate key exponent should be odd and >2^16: 1
+  Priority: Info, Message: commonName field is deprecated
+  Priority: Info, Message: emailAddress field is deprecated

--- a/testdata/gtenonsan.pem.golden
+++ b/testdata/gtenonsan.pem.golden
@@ -1,0 +1,8 @@
+Incomplete chain for Cybertrust Public SureServer SV CA *.whitehouse.gov 20000000001456be1a50e66883e &{[{4 Using deprecated TeletexString for '*.whitehouse.gov'}] <nil> 4 {0 0}}
+Processed Certificate Type: OV
+Certificate Errors: 5
+  Priority: Warning, Message: Using deprecated TeletexString for '*.whitehouse.gov'
+  Priority: Error, Message: Certificate contains no Authority Info Access Issuers
+  Priority: Warning, Message: Certificate contains unknown extension (2.16.840.1.113730.1.1)
+  Priority: Info, Message: commonName field is deprecated
+  Priority: Error, Message: Certificate doesn't contain any subjectAltName

--- a/testdata/invalid_encoding1.pem.golden
+++ b/testdata/invalid_encoding1.pem.golden
@@ -1,0 +1,6 @@
+Processed Certificate Type: EV
+Certificate Errors: 4
+  Priority: Warning, Message: Using deprecated TeletexString for '上海市'
+  Priority: Warning, Message: Using deprecated TeletexString for '上海市'
+  Priority: Error, Message: Certificate contains an extended key usage different from ServerAuth, ClientAuth or ServerGatedCrypto
+  Priority: Info, Message: commonName field is deprecated

--- a/testdata/invalid_encoding2.pem.golden
+++ b/testdata/invalid_encoding2.pem.golden
@@ -1,0 +1,4 @@
+Processed Certificate Type: EV
+Certificate Errors: 2
+  Priority: Warning, Message: Using deprecated TeletexString for 'Düsseldorf'
+  Priority: Info, Message: commonName field is deprecated

--- a/testdata/ivissues.pem.golden
+++ b/testdata/ivissues.pem.golden
@@ -1,0 +1,6 @@
+Processed Certificate Type: IV
+Certificate Errors: 4
+  Priority: Warning, Message: Certificate contains unknown extension (2.5.29.18)
+  Priority: Error, Message: localityName or stateOrProvinceName is required if organizationName is set
+  Priority: Error, Message: stateOrProvinceName is required if organizationName is set
+  Priority: Info, Message: commonName field is deprecated

--- a/testdata/kuandcnnotinsan.pem.golden
+++ b/testdata/kuandcnnotinsan.pem.golden
@@ -1,0 +1,10 @@
+Processed Certificate Type: EV
+Certificate Errors: 8
+  Priority: Error, Message: Certificate has key usage KeyAgreement set
+  Priority: Error, Message: businessCategory is required for EV certificates
+  Priority: Error, Message: jurisdictionCountryName is required for EV certificates
+  Priority: Error, Message: stateOrProvinceName is required if organizationName is set
+  Priority: Info, Message: commonName field is deprecated
+  Priority: Error, Message: Certificate CN is not listed in subjectAltName
+  Priority: Error, Message: Certificate subjectAltName '*.passbyme.com' should not contain a wildcard
+  Priority: Error, Message: Certificate subjectAltName '*.passbyme.net' should not contain a wildcard

--- a/testdata/metadata.pem.golden
+++ b/testdata/metadata.pem.golden
@@ -1,0 +1,4 @@
+Processed Certificate Type: OV
+Certificate Errors: 2
+  Priority: Error, Message: Forbidden value in UTF8String '_'
+  Priority: Info, Message: commonName field is deprecated

--- a/testdata/nokeyusage.pem.golden
+++ b/testdata/nokeyusage.pem.golden
@@ -1,0 +1,5 @@
+Processed Certificate Type: OV
+Certificate Errors: 3
+  Priority: Error, Message: Certificate contains no extended key usage
+  Priority: Error, Message: Certificate has no key usage set
+  Priority: Info, Message: commonName field is deprecated

--- a/testdata/notv3.pem.golden
+++ b/testdata/notv3.pem.golden
@@ -1,0 +1,13 @@
+Incomplete chain for ADIF CA consejo.adifaltavelocidad.es 81228d7efe84370b394fbd52dad59884 &{[] <nil> 0 {0 0}}
+Processed Certificate Type: PS
+Certificate Errors: 10
+  Priority: Error, Message: Certificate contains no Authority Info Access Issuers
+  Priority: Error, Message: Certificate contains no extended key usage
+  Priority: Error, Message: Certificate has no key usage set
+  Priority: Error, Message: Certificate key too small: 1024
+  Priority: Error, Message: Certificate contains no CRL or OCSP server
+  Priority: Info, Message: emailAddress field is deprecated
+  Priority: Error, Message: stateOrProvinceName is required if organizationName is set
+  Priority: Info, Message: commonName field is deprecated
+  Priority: Error, Message: Certificate doesn't contain any subjectAltName
+  Priority: Error, Message: Certificate is not V3 (1)

--- a/testdata/notv3_2.pem.golden
+++ b/testdata/notv3_2.pem.golden
@@ -1,0 +1,10 @@
+Incomplete chain for Trustis Healthcare TT Issuing Authority *.bartshealth.nhs.uk a617a0c28282b8ab3398cbfb392c6a47 &{[] <nil> 0 {0 0}}
+Processed Certificate Type: OV
+Certificate Errors: 7
+  Priority: Error, Message: Certificate contains no Authority Info Access Issuers
+  Priority: Error, Message: Certificate contains no extended key usage
+  Priority: Error, Message: Certificate has no key usage set
+  Priority: Error, Message: Certificate contains no CRL or OCSP server
+  Priority: Info, Message: commonName field is deprecated
+  Priority: Error, Message: Certificate doesn't contain any subjectAltName
+  Priority: Error, Message: Certificate is not V3 (1)


### PR DESCRIPTION
If CLI output format changes, must re-generate golden files.

This change is somewhat large and complex. Certainly I would value any sort of feedback/discussion about these new tests.
This change increases the time required for tests to run.