### PR TITLE
CI: Few small improvements. Vetting, vet err fixes, Go 1.10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: go
 go:
+  - 1.10
   - 1.9
   - 1.8
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,12 @@ before_install:
   - go get -t -v ./...
 
 script:
+  - go vet ./...
   - go test -race -coverprofile=coverage.txt -covermode=atomic
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  
+
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: go
 go:
-  - 1.10
+  - "1.10"
   - 1.9
   - 1.8
   - master

--- a/asn1/format_test.go
+++ b/asn1/format_test.go
@@ -10,7 +10,7 @@ func TestIsForbiddenString(t *testing.T) {
 
 	for _, v := range forbidden {
 		if !isForbiddenString([]byte(v)) {
-			t.Errorf("Forbidden string passed check", v)
+			t.Errorf("Forbidden string passed check: %q", v)
 		}
 	}
 
@@ -19,7 +19,7 @@ func TestIsForbiddenString(t *testing.T) {
 
 	for _, v := range accepted {
 		if isForbiddenString([]byte(v)) {
-			t.Errorf("Accepted string did not pass check", v)
+			t.Errorf("Accepted string did not pass check: %q", v)
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes two small format specifier string errors in `asn1/format_test.go`. To prevent these kinds of bugs from slipping in again in the future this PR updates the `.travis.yml` for CI to run `go vet` during the `script` phase of the build. Lastly, this PR adds Go version `1.10` to the `.travis.yml`.