### PR TITLE
extensions checks: Add OCSP must staple check.

### DIFF
--- a/checks/extensions/all/all.go
+++ b/checks/extensions/all/all.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/globalsign/certlint/checks/extensions/extkeyusage"
 	_ "github.com/globalsign/certlint/checks/extensions/keyusage"
 	_ "github.com/globalsign/certlint/checks/extensions/nameconstraints"
+	_ "github.com/globalsign/certlint/checks/extensions/ocspmuststaple"
 	_ "github.com/globalsign/certlint/checks/extensions/ocspnocheck"
 	_ "github.com/globalsign/certlint/checks/extensions/pdfrevocation"
 	_ "github.com/globalsign/certlint/checks/extensions/policyidentifiers"

--- a/checks/extensions/ocspmuststaple/ocspmuststaple.go
+++ b/checks/extensions/ocspmuststaple/ocspmuststaple.go
@@ -1,0 +1,37 @@
+package ocspmuststaple
+
+import (
+	"crypto/x509/pkix"
+	"encoding/asn1"
+
+	"github.com/globalsign/certlint/certdata"
+	"github.com/globalsign/certlint/checks"
+	"github.com/globalsign/certlint/errors"
+)
+
+const checkName = "OCSP Must Staple Extension Check"
+
+// See RFC 7633
+var extensionOid = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24}
+
+func init() {
+	checks.RegisterExtensionCheck(checkName, extensionOid, nil, Check)
+}
+
+// Check performs a strict verification on the extension according to the standard(s)
+func Check(ex pkix.Extension, d *certdata.Data) *errors.Errors {
+	var e = errors.New(nil)
+
+	// RFC 7633 only defines this extension for PKIX end-entity certificates,
+	// certificate signing requests, and certificate signing certificates (CAs)
+	if d.Type == "OCSP" {
+		e.Err("OCSP Must Staple extension set in non end-entity/issuer certificate")
+	}
+
+	// Per RFC 7633 "The TLS feature extension SHOULD NOT be marked critical"
+	if ex.Critical {
+		e.Err("OCSP Must Staple extension set critical")
+	}
+
+	return e
+}


### PR DESCRIPTION
This commit adds a check for the OCSP Must Staple x509v3 feature
extension defined in RFC 7633. Prior to this commit running `certlint`
on a certificate with this extension produced output like:

```
Bad Certificates Detected: {
  'xxxx': {
    'valid': False,
    'problems': [
      'Certificate contains unknown extension (1.3.6.1.5.5.7.1.24)'
    ]
  }
}
```

The OCSP Must Staple check presently enforces that:
1) The `certdata.Data.Type` is not OCSP. The RFC only defines this
   extension for end entity certificates, CSRs, and issuing
   certificates, not OCSP signing certificates.
2) The `ex.Critical` flag is set to false. The RFC forbids setting this
   extension to critical.

After applying this commit the above Bad Certificate Detected problem is
resolved.

_*Note to reviewers:* I did not find any unit tests for the existing 
`certlint/extensions/` checks so I haven't tried to write one for this 
addition. I did verify using known good certificates both with/without 
the extension. If there is an example unit test to refer to I can attempt
to add one for the OCSP Must Staple check._