### PR TITLE
CI: Add caching to travis builds to improve speed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ go:
   - 1.8
   - master
 
+cache:
+  directories:
+    - $GOPATH/src
+    - $GOPATH/pkg
+
 before_install:
   - go get -t -v ./...
 


### PR DESCRIPTION
This commits add `cache` directives to the `.travis.yml` for the
`$GOPATH/src` and `$GOPATH/pkg` directories. This should result in CI
speed improvements. See https://docs.travis-ci.com/user/caching/ for
more detail.

_*Note to reviewers*: I wasn't able to test this ahead of submitting a PR.
The project structure, fully qualified imports, and use of an `internal` 
package name mean CI for all forks fails during `go get -t -v ./...`. I'll 
try to submit a fix for this Monday_