### PR TITLE
extensions checks: Add OCSP must staple check.

### DIFF
--- a/checks/extensions/all/all.go
+++ b/checks/extensions/all/all.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/globalsign/certlint/checks/extensions/extkeyusage"
 	_ "github.com/globalsign/certlint/checks/extensions/keyusage"
 	_ "github.com/globalsign/certlint/checks/extensions/nameconstraints"
+	_ "github.com/globalsign/certlint/checks/extensions/ocspmuststaple"
 	_ "github.com/globalsign/certlint/checks/extensions/ocspnocheck"
 	_ "github.com/globalsign/certlint/checks/extensions/pdfrevocation"
 	_ "github.com/globalsign/certlint/checks/extensions/policyidentifiers"

--- a/checks/extensions/ocspmuststaple/ocspmuststaple.go
+++ b/checks/extensions/ocspmuststaple/ocspmuststaple.go
@@ -1,20 +1,44 @@
 package ocspmuststaple
 
 import (
+	"bytes"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"fmt"
 
 	"github.com/globalsign/certlint/certdata"
 	"github.com/globalsign/certlint/checks"
 	"github.com/globalsign/certlint/errors"
 )
 
-const checkName = "OCSP Must Staple Extension Check"
+const (
+	checkName   = "OCSP Must Staple Extension Check"
+	certTypeErr = "OCSP Must Staple extension set in non end-entity/issuer certificate"
+	critExtErr  = "OCSP Must Staple extension set critical"
+)
 
-// See RFC 7633
-var extensionOid = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24}
+var (
+	// RFC 7633 OID of the OCSP Must Staple TLS Extension Feature
+	extensionOid = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24}
+	// Expected extension value (DER encoded ASN.1 bytestring)
+	expectedExtensionValue = []uint8{0x30, 0x3, 0x2, 0x1, 0x5}
+	extValueErr            = fmt.Sprintf(
+		"OCSP Must Staple extension had incorrect value. "+
+			"Should be ASN.1 DER %#v", expectedExtensionValue)
+)
+
+// RFC 7633 only defines this extension for PKIX end-entity certificates,
+// certificate signing requests, and certificate signing certificates (CAs).
+// We should not allow it for cert types like "OCSP", "PS", "CS", etc.
+var allowedCertTypes = map[string]bool{
+	"DV": true,
+	"OV": true,
+	"EV": true,
+	"CA": true,
+}
 
 func init() {
+	// Register this check for the OCSP Must Staple extension OID.
 	checks.RegisterExtensionCheck(checkName, extensionOid, nil, Check)
 }
 
@@ -22,15 +46,19 @@ func init() {
 func Check(ex pkix.Extension, d *certdata.Data) *errors.Errors {
 	var e = errors.New(nil)
 
-	// RFC 7633 only defines this extension for PKIX end-entity certificates,
-	// certificate signing requests, and certificate signing certificates (CAs)
-	if d.Type == "OCSP" {
-		e.Err("OCSP Must Staple extension set in non end-entity/issuer certificate")
+	// If the cert type isn't one of the `allowedCertTypes`, return an error
+	if _, allowed := allowedCertTypes[d.Type]; !allowed {
+		e.Err(certTypeErr)
 	}
 
 	// Per RFC 7633 "The TLS feature extension SHOULD NOT be marked critical"
 	if ex.Critical {
-		e.Err("OCSP Must Staple extension set critical")
+		e.Err(critExtErr)
+	}
+
+	// Check that the extension value is the expected slice of DER encoded ASN.1
+	if bytes.Compare(ex.Value, expectedExtensionValue) != 0 {
+		e.Err(extValueErr)
 	}
 
 	return e

--- a/checks/extensions/ocspmuststaple/ocspmuststaple.go
+++ b/checks/extensions/ocspmuststaple/ocspmuststaple.go
@@ -1,0 +1,37 @@
+package ocspmuststaple
+
+import (
+	"crypto/x509/pkix"
+	"encoding/asn1"
+
+	"github.com/globalsign/certlint/certdata"
+	"github.com/globalsign/certlint/checks"
+	"github.com/globalsign/certlint/errors"
+)
+
+const checkName = "OCSP Must Staple Extension Check"
+
+// See RFC 7633
+var extensionOid = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24}
+
+func init() {
+	checks.RegisterExtensionCheck(checkName, extensionOid, nil, Check)
+}
+
+// Check performs a strict verification on the extension according to the standard(s)
+func Check(ex pkix.Extension, d *certdata.Data) *errors.Errors {
+	var e = errors.New(nil)
+
+	// RFC 7633 only defines this extension for PKIX end-entity certificates,
+	// certificate signing requests, and certificate signing certificates (CAs)
+	if d.Type == "OCSP" {
+		e.Err("OCSP Must Staple extension set in non end-entity/issuer certificate")
+	}
+
+	// Per RFC 7633 "The TLS feature extension SHOULD NOT be marked critical"
+	if ex.Critical {
+		e.Err("OCSP Must Staple extension set critical")
+	}
+
+	return e
+}

--- a/checks/extensions/ocspmuststaple/ocspmuststaple_test.go
+++ b/checks/extensions/ocspmuststaple/ocspmuststaple_test.go
@@ -1,0 +1,133 @@
+package ocspmuststaple
+
+import (
+	"crypto/x509/pkix"
+	"testing"
+
+	"github.com/globalsign/certlint/certdata"
+)
+
+// TestCheck tests the OCSP Must Staple extension Check() behaves as expected
+// with valid/invalid testcases.
+func TestCheck(t *testing.T) {
+	// Valid OCSP Must Staple Extension.
+	validExtension := pkix.Extension{
+		Id:       extensionOid,
+		Value:    expectedExtensionValue,
+		Critical: false,
+	}
+	// Invalid OCSP Must Staple Extension: Critical field set to `true`.
+	criticalExtension := pkix.Extension{
+		Id:       extensionOid,
+		Value:    expectedExtensionValue,
+		Critical: true,
+	}
+	// Invalid OCSP Must Staple Extension: Wrong value.
+	wrongValueExtension := pkix.Extension{
+		Id:       extensionOid,
+		Value:    []uint8{0xC0, 0xFF, 0xEE},
+		Critical: false,
+	}
+	// Invalid OCSP Must Staple Extension: Wrong value, Critical field set to
+	// `true`
+	wrongValueExtensionCritical := pkix.Extension{
+		Id:       extensionOid,
+		Value:    []uint8{0xC0, 0xFF, 0xEE},
+		Critical: true,
+	}
+
+	testCases := []struct {
+		Name           string
+		InputEx        pkix.Extension
+		CertType       string
+		ExpectedErrors []string
+	}{
+		{
+			Name:           "Valid: DV cert type",
+			InputEx:        validExtension,
+			CertType:       "DV",
+			ExpectedErrors: []string{},
+		},
+		{
+			Name:           "Valid: OV cert type",
+			InputEx:        validExtension,
+			CertType:       "DV",
+			ExpectedErrors: []string{},
+		},
+		{
+			Name:           "Valid: EV cert type",
+			InputEx:        validExtension,
+			CertType:       "DV",
+			ExpectedErrors: []string{},
+		},
+		{
+			Name:           "Valid: CA cert type",
+			InputEx:        validExtension,
+			CertType:       "CA",
+			ExpectedErrors: []string{},
+		},
+		{
+			Name:     "Invalid: OCSP cert type",
+			InputEx:  validExtension,
+			CertType: "OCSP",
+			ExpectedErrors: []string{
+				certTypeErr,
+			},
+		},
+		{
+			Name:           "Invalid: critical extension",
+			InputEx:        criticalExtension,
+			CertType:       "DV",
+			ExpectedErrors: []string{critExtErr},
+		},
+		{
+			Name:     "Invalid: critical extension, OCSP cert type",
+			InputEx:  criticalExtension,
+			CertType: "OCSP",
+			ExpectedErrors: []string{
+				certTypeErr, critExtErr,
+			},
+		},
+		{
+			Name:     "Invalid: wrong extension value",
+			InputEx:  wrongValueExtension,
+			CertType: "DV",
+			ExpectedErrors: []string{
+				extValueErr,
+			},
+		},
+		{
+			Name:     "Invalid: wrong extension value, critical extension, OCSP cert type",
+			InputEx:  wrongValueExtensionCritical,
+			CertType: "OCSP",
+			ExpectedErrors: []string{
+				certTypeErr, critExtErr, extValueErr,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			certData := &certdata.Data{
+				Type: tc.CertType,
+			}
+			// Run the OCSP Must Staple check on the test data
+			errors := Check(tc.InputEx, certData)
+			// Collect the returned errors into a list
+			errList := errors.List()
+			// Verify the expected number of errors are in the list
+			if len(tc.ExpectedErrors) != len(errList) {
+				t.Errorf("wrong number of Check errors: expected %d, got %d\n",
+					len(tc.ExpectedErrors), len(errList))
+			} else {
+				// Match the error list to the expected error list
+				for i, err := range errList {
+					if errMsg := err.Error(); errMsg != tc.ExpectedErrors[i] {
+						t.Errorf("expected error %q at index %d, got %q",
+							tc.ExpectedErrors[i], i, errMsg)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR (replacing https://github.com/globalsign/certlint/pull/13) adds a check for the OCSP Must Staple x509v3 feature extension defined in RFC 7633. Prior to this commit running `certlint` on a certificate with this extension produced output like:

```
Bad Certificates Detected: {
  'xxxx': {
    'valid': False,
    'problems': [
      'Certificate contains unknown extension (1.3.6.1.5.5.7.1.24)'
    ]
  }
}
```

The new OCSP Must Staple check enforces that:
1) The `certdata.Data.Type` is one of DV, OV, EV or CA.
2) The `ex.Critical` flag is set to false. The RFC forbids setting this extension to critical.
3) The `ex.Value` is the expected DER encoded ASN.1 byte string 

A unit test is added to ensure all of the above functions correctly. After applying this PR the above mentioned Bad Certificate Detected problem is resolved for a known-valid OCSP Must Staple certificate.

