### PR TITLE
Small typo/lint fixes.

### DIFF
--- a/asn1/format.go
+++ b/asn1/format.go
@@ -211,7 +211,7 @@ func isForbiddenString(b []byte) bool {
 			(r >= 58 && r <= 64) ||
 			(r >= 91 && r <= 96) ||
 			(r >= 123 && r <= 126)) {
-			// non metadata character inlcuded in value
+			// non metadata character included in value
 			return false
 		}
 		b = b[size:]

--- a/certlint.go
+++ b/certlint.go
@@ -257,7 +257,7 @@ func do(icaCache *lru.Cache, der []byte, exp, rtrn bool) testResult {
 					Intermediates: pool,
 					KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 				}
-				if chain, err = d.Cert.Verify(opts); err != nil {
+				if _, err = d.Cert.Verify(opts); err != nil {
 					result.Trusted = false
 				}
 

--- a/checks/certificate/subject/oid.go
+++ b/checks/certificate/subject/oid.go
@@ -18,7 +18,7 @@ func (o *object) Equal(oid asn1.ObjectIdentifier) bool {
 
 func (o *object) Valid(v interface{}) error {
 	if o.maxLength > 0 && len([]rune(v.(string))) > o.maxLength {
-		return fmt.Errorf("exeeding max length of %d", o.maxLength)
+		return fmt.Errorf("exceeding max length of %d", o.maxLength)
 	}
 	return nil
 }

--- a/checks/certificate/subject/subject.go
+++ b/checks/certificate/subject/subject.go
@@ -65,7 +65,7 @@ func checkDN(vetting string, dn []pkix.AttributeTypeAndValue) *errors.Errors {
 		// commonName
 		// If present, this field MUST contain a single IP address or Fully‐Qualified Domain Name
 		case commonName.Equal(n.Type):
-			// report deprecated common name field as info untill not commenly used/accepted
+			// report deprecated common name field as info until not commenly used/accepted
 			e.Info("commonName field is deprecated")
 
 			// check if value is exceeding max length
@@ -74,7 +74,7 @@ func checkDN(vetting string, dn []pkix.AttributeTypeAndValue) *errors.Errors {
 			}
 
 		case emailAddress.Equal(n.Type):
-			// report deprecated email address field as info untill not commenly used/accepted
+			// report deprecated email address field as info until not commenly used/accepted
 			e.Info("emailAddress field is deprecated")
 
 			// RFC5280: ub-emailaddress-length was changed from 128 to 255 in order to


### PR DESCRIPTION
* checks: subject.go 'untill' comment typo fixes
* checks: oid.go 'exeeding' typo
* asn1: format.go 'inlcuded' comment typo fix
* Certlint: remove unused 'chain' assignment
