### PR TITLE
Modified subject check relating to organizationName

### DIFF
--- a/checks/certificate/subject/subject.go
+++ b/checks/certificate/subject/subject.go
@@ -165,9 +165,6 @@ func checkDN(vetting string, dn []pkix.AttributeTypeAndValue) *errors.Errors {
 			if !inDN(dn, localityName) && !inDN(dn, stateOrProvinceName) {
 				e.Err("localityName or stateOrProvinceName is required if organizationName is set")
 			}
-			if !inDN(dn, stateOrProvinceName) {
-				e.Err("stateOrProvinceName is required if organizationName is set")
-			}
 			if !inDN(dn, countryName) {
 				e.Err("countryName is required if organizationName is set")
 			}


### PR DESCRIPTION
Hello, please consider merging this commit:

Modified subject checks to no longer flag an error under the scenario of: organizationName present, localityName present, stateOrProvinceName not present.

CAB baseline requirements version 1.6.0 (and prior versions) section 7.1.4.2.2 (f) allows this scenario.

Note:
Right above the 3 lines I removed, there is a check that properly requires that either localityName or stateOrProvinceName must be present if organizationName is present.  I suspect that those 3 lines were meant to replace the 3 lines that this commit removes.

Thanks,
Bryan