### PR TITLE
validity check changes

### DIFF
--- a/checks/certificate/validity/validity.go
+++ b/checks/certificate/validity/validity.go
@@ -20,12 +20,24 @@ func Check(d *certdata.Data) *errors.Errors {
 
 	switch d.Type {
 	case "EV":
-		if d.Cert.NotAfter.After(d.Cert.NotBefore.AddDate(0, 27, 0)) {
-			e.Err("EV Certificate LifeTime exceeds 27 months")
-			return e
+		if d.Cert.NotBefore.After(time.Date(2017, 3, 17, 0, 0, 0, 0, time.UTC)) {
+			if d.Cert.NotAfter.After(d.Cert.NotBefore.AddDate(0, 0, 825)) {
+				e.Err("EV Certificate LifeTime exceeds 825 days")
+				return e
+			}
+		} else {
+			if d.Cert.NotAfter.After(d.Cert.NotBefore.AddDate(0, 27, 0)) {
+				e.Err("EV Certificate LifeTime exceeds 27 months")
+				return e
+			}
 		}
 	case "DV", "OV":
-		if d.Cert.NotBefore.After(time.Date(2015, 4, 1, 0, 0, 0, 0, time.UTC)) {
+		if d.Cert.NotBefore.After(time.Date(2018, 3, 1, 0, 0, 0, 0, time.UTC)) {
+			if d.Cert.NotAfter.After(d.Cert.NotBefore.AddDate(0, 0, 825)) {
+				e.Err("Certificate LifeTime exceeds 825 days")
+				return e
+			}
+		} else if d.Cert.NotBefore.After(time.Date(2016, 7, 1, 0, 0, 0, 0, time.UTC)) {
 			if d.Cert.NotAfter.After(d.Cert.NotBefore.AddDate(0, 39, 0)) {
 				e.Err("Certificate LifeTime exceeds 39 months")
 				return e

--- a/checks/certificate/validity/validity.go
+++ b/checks/certificate/validity/validity.go
@@ -20,18 +20,18 @@ func Check(d *certdata.Data) *errors.Errors {
 
 	switch d.Type {
 	case "EV":
-		if d.Cert.NotBefore.After(d.Cert.NotBefore.AddDate(0, 27, 0)) {
+		if d.Cert.NotAfter.After(d.Cert.NotBefore.AddDate(0, 27, 0)) {
 			e.Err("EV Certificate LifeTime exceeds 27 months")
 			return e
 		}
 	case "DV", "OV":
 		if d.Cert.NotBefore.After(time.Date(2015, 4, 1, 0, 0, 0, 0, time.UTC)) {
-			if d.Cert.NotBefore.After(d.Cert.NotBefore.AddDate(0, 39, 0)) {
+			if d.Cert.NotAfter.After(d.Cert.NotBefore.AddDate(0, 39, 0)) {
 				e.Err("Certificate LifeTime exceeds 39 months")
 				return e
 			}
 		} else {
-			if d.Cert.NotBefore.After(d.Cert.NotBefore.AddDate(0, 60, 0)) {
+			if d.Cert.NotAfter.After(d.Cert.NotBefore.AddDate(0, 60, 0)) {
 				e.Err("Certificate LifeTime exceeds 60 months")
 				return e
 			}

--- a/testdata/evissues.pem.golden
+++ b/testdata/evissues.pem.golden
@@ -1,8 +1,9 @@
 Incomplete chain for VR IDENT EV SSL CA 2016 W1.DONNER.DE 68636c860bca0d94ab2be &{[] <nil> 0 {0 0}}
 Processed Certificate Type: EV
-Certificate Errors: 5
+Certificate Errors: 6
   Priority: Error, Message: Certificate contains no Authority Info Access Issuers
   Priority: Error, Message: businessCategory is required for EV certificates
   Priority: Error, Message: jurisdictionCountryName is required for EV certificates
   Priority: Error, Message: serialNumber is required for EV certificates
   Priority: Info, Message: commonName field is deprecated
+  Priority: Error, Message: EV Certificate LifeTime exceeds 27 months


### PR DESCRIPTION
Hi, thanks for providing the community with your excellent linting tool - a lot of people have benefited from this.  

Please consider merging this pull request.  There are a couple commits I've made to improve validity checking.

1. The first is to correct a typo on a variable comparison that resulted in the validity checks always passing previously.  Now the comparisons are for NotAfter > (NotBefore + offset)

2. The second is to take into account recent BR and EV guidelines on allowed validity duration.  This was a little tricky to determine all the rules based on different issuance dates that reflected different CAB guidance over time.  I've reviewed the guidelines and relevant ballot and I think the updated checks have it covered.  Specifically:
 - Ballot 193 was adopted into BR 1.4.4 with an effective date of 2018-03-01.  The adopted guidance states: "Subscriber Certificates issued after 1 March 2018 MUST have a Validity Period no greater than 825 days.  Subscriber Certificates issued after 1 July 2016 but prior to 1 March 2018 MUST have a Validity Period no greater than 39 months."  Certs issued prior to 2016-07-01 are allowed to live up to 60 months.
  - Ballot 193 was adopted into EV Guidelines 1.6.2 effective 2017-03-17.  This allows EV SSL certs to live no longer than 825 days.  Prior to this, EV SSL certs were allowed to live 27 months.  I debated simplifying the logic to just allow 825 regardless of issuance date since 825 days is so close to 27 months.  In the end I decided that the more precise checking depending on date of issuance might be valuable.


